### PR TITLE
[APP-8695] Change to reading errors

### DIFF
--- a/lib/src/bluetooth_device_extensions.dart
+++ b/lib/src/bluetooth_device_extensions.dart
@@ -42,14 +42,17 @@ extension ViamReading on BluetoothDevice {
     return (isConfigured: isConfigured, isConnected: isConnected);
   }
 
-  Future<String> readErrors() async {
+  Future<List<String>> readErrors() async {
     List<BluetoothService> services = await discoverServices();
 
     final bleService = services.firstWhere((service) => service.uuid.str == ViamBluetoothUUIDs.serviceUUID);
 
     final errorsCharacteristic = bleService.characteristics.firstWhere((char) => char.uuid.str == ViamBluetoothUUIDs.errorsUUID);
     final errorsBytes = await errorsCharacteristic.read();
-    return utf8.decode(errorsBytes);
+    final errorsString = String.fromCharCodes(errorsBytes); // not decoding with uf8 or it stops at first null byte
+    // split by null bytes and filter out empty strings
+    final errorList = errorsString.split('\x00').where((error) => error.isNotEmpty).toList();
+    return errorList;
   }
 
   Future<String> readFragmentId() async {

--- a/viam_example_app/lib/provision_peripheral_screen.dart
+++ b/viam_example_app/lib/provision_peripheral_screen.dart
@@ -21,12 +21,15 @@ class _ProvisionPeripheralScreen extends State<ProvisionPeripheralScreen> {
   List<String> _networkList = [];
 
   bool _isLoadingNetworkList = false;
+  bool _isLoadingErrors = false;
   bool _isWritingNetworkConfig = false;
   bool _isWritingRobotPartConfig = false;
 
   bool _isLoadingStatus = false;
   bool _isConfigured = false;
   bool _isConnected = false;
+
+  String _errors = '';
 
   @override
   void initState() {
@@ -84,6 +87,24 @@ class _ProvisionPeripheralScreen extends State<ProvisionPeripheralScreen> {
     } finally {
       setState(() {
         _isLoadingStatus = false;
+      });
+    }
+  }
+
+  void _readErrors() async {
+    setState(() {
+      _isLoadingErrors = true;
+    });
+    try {
+      final errors = await widget.device.readErrors();
+      setState(() {
+        _errors = errors.join('\n');
+      });
+    } catch (e) {
+      debugPrint('Error reading errors: ${e.toString()}');
+    } finally {
+      setState(() {
+        _isLoadingErrors = false;
       });
     }
   }
@@ -168,6 +189,12 @@ class _ProvisionPeripheralScreen extends State<ProvisionPeripheralScreen> {
               FilledButton(
                 onPressed: _isLoadingStatus ? null : _readStatus,
                 child: _isLoadingStatus ? const CircularProgressIndicator.adaptive() : const Text('Read Status'),
+              ),
+              const SizedBox(height: 16),
+              Text(_errors),
+              FilledButton(
+                onPressed: _isLoadingErrors ? null : _readErrors,
+                child: _isLoadingErrors ? const CircularProgressIndicator.adaptive() : const Text('Read Errors'),
               ),
               const SizedBox(height: 16),
               TextField(


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-8695

The errors come through as a list, separated by a null byte (`0`). When using the default utf8 decoding it will stop the decoding when it hits the null byte, so we need to decode a bit differently and change the interface to return a list