### PR TITLE
Turn off FlutterBluePlus logging

### DIFF
--- a/lib/src/viam_bluetooth_provisioning.dart
+++ b/lib/src/viam_bluetooth_provisioning.dart
@@ -2,7 +2,6 @@ part of '../viam_bluetooth_provisioning.dart';
 
 class ViamBluetoothProvisioning {
   static Future<void> initialize({Function(bool)? poweredOn}) async {
-    FlutterBluePlus.setLogLevel(LogLevel.verbose, color: false);
     FlutterBluePlus.adapterState.listen((BluetoothAdapterState state) {
       if (state == BluetoothAdapterState.on) {
         poweredOn?.call(true);


### PR DESCRIPTION
The user could decide on this if they want, was good for developing but way too noisy right now to be on all the time