### PR TITLE
Change empty password NONE to empty

### DIFF
--- a/lib/src/bluetooth_device_extensions.dart
+++ b/lib/src/bluetooth_device_extensions.dart
@@ -166,7 +166,7 @@ extension ViamWriting on BluetoothDevice {
     );
     await ssidCharacteristic.write(encodedSSID);
 
-    final encodedPW = encoder.process(utf8.encode('$psk:${pw ?? 'NONE'}'));
+    final encodedPW = encoder.process(utf8.encode('$psk:${pw ?? ''}'));
     final pskCharacteristic = bleService.characteristics.firstWhere(
       (char) => char.uuid.str == ViamBluetoothUUIDs.pskUUID,
       orElse: () => throw Exception('pskCharacteristic not found'),


### PR DESCRIPTION
Based on changes to [agent](https://github.com/viamrobotics/agent/blob/738f82761751a008d5c850dd3b6a738829681ae3/subsystems/networking/networkmanager_linux.go#L458) this no longer checks for `NONE` but an actual empty string for unsecured networks