### PR TITLE
APP-9184 fix discoverServices failure with clearGattCache

### DIFF
--- a/lib/src/bluetooth_device_extensions.dart
+++ b/lib/src/bluetooth_device_extensions.dart
@@ -24,7 +24,7 @@ extension ViamReading on BluetoothDevice {
           .firstOrNull;
       if (bleService != null) return bleService;
       if (i < attempts - 1) {
-        debugPrint("clearing gatt cache");
+        // debugPrint("clearing gatt cache");
         await clearGattCache();
       }
     }

--- a/lib/src/bluetooth_device_extensions.dart
+++ b/lib/src/bluetooth_device_extensions.dart
@@ -24,7 +24,6 @@ extension ViamReading on BluetoothDevice {
           .firstOrNull;
       if (bleService != null) return bleService;
       if (i < attempts - 1) {
-        // debugPrint("clearing gatt cache");
         await clearGattCache();
       }
     }


### PR DESCRIPTION
## What changed
- create getBleService method + use instead of boilerplate
- clear GATT cache + retry if getBleService fails
## Why
Our flow does a handoff like this:

```mermaid
sequenceDiagram;
  participant user;
  app->>pi: disconnect BLE;
  user->>pi: pair BT classic from phone menu;
  app->>pi: reconnect BLE;
```

On android, after the reconnect, the [discoverServices call](https://github.com/chipweinberger/flutter_blue_plus/blob/dd5fc977fb57086b21fc4a46ac3966c941696ae6/packages/flutter_blue_plus_android/lib/flutter_blue_plus_android.dart#L152) comes back with 0 services, and stays that way forever, likely because of gatt caching. Clearing the GATT cache seems to fix.