### PR TITLE
[no-ticket] Add platform check before clearGattCache call

### DIFF
--- a/lib/src/bluetooth_device_extensions.dart
+++ b/lib/src/bluetooth_device_extensions.dart
@@ -24,7 +24,7 @@ extension ViamReading on BluetoothDevice {
           .firstOrNull;
       if (bleService != null) return bleService;
       if (i < attempts - 1) {
-        await clearGattCache();
+        if (Platform.isAndroid) await clearGattCache();
       }
     }
     throw Exception('bleService not found after $attempts attempts');

--- a/lib/viam_bluetooth_provisioning.dart
+++ b/lib/viam_bluetooth_provisioning.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:convert';
 import 'dart:typed_data';
 


### PR DESCRIPTION
This call is only available on Android.

In the function implementation there is a platform check that then throws. We call this on iOS and it ends up showing up in the logs and adding extra noise.